### PR TITLE
Update local.cfg.EXAMPLE

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -33,12 +33,14 @@
 dspace.dir=/dspace
 
 # URL of DSpace backend ('server' webapp). Include port number etc.
+# DO NOT include 443 port number
 # DO NOT end it with '/'.
 # This is where REST API and all enabled server modules (OAI-PMH, SWORD,
 # SWORDv2, RDF, etc) will respond.
 dspace.server.url = http://localhost:8080/server
 
 # URL of DSpace frontend (Angular UI). Include port number etc.
+# DO NOT include 443 port number
 # DO NOT end it with '/'.
 # This is used by the backend to provide links in emails, RSS feeds, Sitemaps,
 # etc.


### PR DESCRIPTION
Just added that the port 443 should not be added by dspace.server.url or by dspace.ui.url

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #8204
* Related to [REST Contract](https://github.com/DSpace/Rest7Contract)

## Description
Just added that the port 443 should not be added by dspace.server.url or by dspace.ui.url

## Instructions for Reviewers
No Code only helpfull for setting it up, not to make the same mistake I made.